### PR TITLE
Support rails STDOUT logging

### DIFF
--- a/lib/buffered_logger/rails.rb
+++ b/lib/buffered_logger/rails.rb
@@ -6,17 +6,22 @@ class BufferedLogger
     initializer :buffered_logger, :before => :initialize_logger do |app|
       next if app.config.logger
 
-      if Rails::VERSION::STRING >= "3.1"
-        path = app.paths["log"].first
+      logdev = if defined? RailsStdoutLogging
+        STDOUT
       else
-        path = app.paths.log.to_a.first
+        if Rails::VERSION::STRING >= "3.1"
+          path = app.paths["log"].first
+        else
+          path = app.paths.log.to_a.first
+        end
+
+        file = File.open(path, "a")
+        file.binmode
+        file.sync = true
+        file
       end
 
-      file = File.open(path, "a")
-      file.binmode
-      file.sync = true
-
-      app.config.logger = BufferedLogger.new(file)
+      app.config.logger = BufferedLogger.new(logdev)
       app.config.logger.level = BufferedLogger.const_get(app.config.log_level.to_s.upcase)
       app.config.middleware.insert(0, BufferedLogger::Middleware, app.config.logger)
     end


### PR DESCRIPTION
Using this gem with a Rails Heroku app fails to initialize. Heroku require log to be output in STDOUT instead of using a file and doing otherwise throw an error on `open(path, "a")`.

This fix checks if the `RailsStdoutLogging` gem is used (Usually used with Heroku rails app) so the Rails initializer can create a STDOUT logdevice instead of using a file.
