### PR TITLE
LogDeviceProxy exception handler

### DIFF
--- a/lib/buffered_logger.rb
+++ b/lib/buffered_logger.rb
@@ -14,6 +14,10 @@ class BufferedLogger < ::Logger
     self.sweep_frequency = 0.02
   end
 
+  def exception_handler=(handler)
+    @logdev.exception_handler = handler
+  end
+
   def end
     raise NotStartedError, "not started" unless started?
     @logdev.end


### PR DESCRIPTION
Adds an exception handler so that applications can specify what to do in those cases (for example server runs out of disk space).

@samuelkadolph @arthurnn @sirupsen
