### PR TITLE
Configure output stream

### DIFF
--- a/lib/buffered_logger/rails.rb
+++ b/lib/buffered_logger/rails.rb
@@ -13,8 +13,10 @@ class BufferedLogger
       output_stream.binmode
       output_stream.sync = true
 
-      app.config.logger = BufferedLogger.new(output_stream)
-      app.config.logger.level = BufferedLogger.const_get(app.config.log_level.to_s.upcase)
+      logger = BufferedLogger.new(output_stream)
+      logger.formatter = app.config.log_formatter
+      logger.level = BufferedLogger.const_get(app.config.log_level.to_s.upcase)
+      app.config.logger = logger
       app.config.middleware.insert(0, BufferedLogger::Middleware, app.config.logger)
     end
 

--- a/lib/buffered_logger/rails.rb
+++ b/lib/buffered_logger/rails.rb
@@ -3,7 +3,7 @@ require "rails"
 
 class BufferedLogger
   class Railtie < Rails::Railtie
-    config.buffered_logger = ActiveSupport::OrderedOptions.new
+    config.buffered_logger = Struct.new(:output_stream).new
 
     initializer :buffered_logger, :before => :initialize_logger do |app|
       next if app.config.logger

--- a/lib/buffered_logger/rails.rb
+++ b/lib/buffered_logger/rails.rb
@@ -15,6 +15,9 @@ class BufferedLogger
 
       logger = BufferedLogger.new(output_stream)
       logger.formatter = app.config.log_formatter
+      if defined?(ActiveSupport::TaggedLogging)
+        logger = ActiveSupport::TaggedLogging.new(logger)
+      end
       logger.level = BufferedLogger.const_get(app.config.log_level.to_s.upcase)
       app.config.logger = logger
       app.config.middleware.insert(0, BufferedLogger::Middleware, app.config.logger)

--- a/lib/buffered_logger/rails.rb
+++ b/lib/buffered_logger/rails.rb
@@ -3,22 +3,29 @@ require "rails"
 
 class BufferedLogger
   class Railtie < Rails::Railtie
+    config.buffered_logger = ActiveSupport::OrderedOptions.new
+
     initializer :buffered_logger, :before => :initialize_logger do |app|
       next if app.config.logger
 
+      output_stream = app.config.buffered_logger.output_stream || default_output_stream(app)
+
+      output_stream.binmode
+      output_stream.sync = true
+
+      app.config.logger = BufferedLogger.new(output_stream)
+      app.config.logger.level = BufferedLogger.const_get(app.config.log_level.to_s.upcase)
+      app.config.middleware.insert(0, BufferedLogger::Middleware, app.config.logger)
+    end
+
+    def default_output_stream(app)
       if Rails::VERSION::STRING >= "3.1"
         path = app.paths["log"].first
       else
         path = app.paths.log.to_a.first
       end
 
-      file = File.open(path, "a")
-      file.binmode
-      file.sync = true
-
-      app.config.logger = BufferedLogger.new(file)
-      app.config.logger.level = BufferedLogger.const_get(app.config.log_level.to_s.upcase)
-      app.config.middleware.insert(0, BufferedLogger::Middleware, app.config.logger)
+      File.open(path, "a")
     end
   end
 end


### PR DESCRIPTION
@samuelkadolph @arthurnn 

Currently the `BufferedLogger` initializer assumes that we're writing to a file. This doesn't work on heroku, because heroku logs to `STDOUT`.

We're starting to use `BufferedLogger` in our heroku apps, so that we'll play nicely with Splunk.

This PR provides an easy way to configure a `BufferedLogger` to write to `STDOUT`, or any other output stream, by setting the `Rails.application.config.buffered_logger.output_stream` variable. The default functionality of `BufferedLogger` (i.e. writing to a log file) is unchanged.

I also added a couple bonus features, while I'm here:

1. Set the formatter on the logger to respect the Rails configuration value in `config.log_formatter`

2. Wrap the logger in a `TaggedLogger`, if `ActiveSupport` is loaded.