### PR TITLE
Use hash cloning to solve thread safety issue

### DIFF
--- a/lib/buffered_logger/log_device_proxy.rb
+++ b/lib/buffered_logger/log_device_proxy.rb
@@ -25,7 +25,7 @@ class BufferedLogger
     end
 
     def started?
-      @buffers.clone.key?(key)
+      @buffers.key?(key)
     end
 
     def sweep

--- a/lib/buffered_logger/log_device_proxy.rb
+++ b/lib/buffered_logger/log_device_proxy.rb
@@ -25,12 +25,12 @@ class BufferedLogger
     end
 
     def started?
-      @buffers.key?(key)
+      @buffers.clone.key?(key)
     end
 
     def sweep
-      @buffers.keep_if do |key, buffer|
-        key.all?(&:alive?)
+      @buffers.clone.each do |key, buffer|
+        @buffers.delete(key) unless key.all?(&:alive?)
       end
       true
     end

--- a/lib/buffered_logger/version.rb
+++ b/lib/buffered_logger/version.rb
@@ -1,5 +1,5 @@
 require "logger"
 
 class BufferedLogger < Logger
-  VERSION = "1.2.1"
+  VERSION = "1.2.2"
 end

--- a/test/buffered_logger_test.rb
+++ b/test/buffered_logger_test.rb
@@ -16,6 +16,13 @@ describe BufferedLogger do
     -> { @logger.start }.must_raise(BufferedLogger::AlreadyStartedError)
   end
 
+  it "does not raise an error with multiple threads working on a BufferedLogger instance" do
+    threads = []
+    thread = Thread.new { @logger.start; @logger.end }
+    10.times { threads << thread }
+    threads.each(&:join)
+  end
+
   if defined?(ActiveSupport)
     it "only logs the string" do
       if defined?(ActiveSupport::Logger::SimpleFormatter)

--- a/test/buffered_logger_test.rb
+++ b/test/buffered_logger_test.rb
@@ -16,13 +16,6 @@ describe BufferedLogger do
     -> { @logger.start }.must_raise(BufferedLogger::AlreadyStartedError)
   end
 
-  it "does not raise an error with multiple threads working on a BufferedLogger instance" do
-    threads = []
-    thread = Thread.new { @logger.start; @logger.end }
-    10.times { threads << thread }
-    threads.each(&:join)
-  end
-
   if defined?(ActiveSupport)
     it "only logs the string" do
       if defined?(ActiveSupport::Logger::SimpleFormatter)


### PR DESCRIPTION
##### Description

This implements the other recommendation found here, https://github.com/samuelkadolph/buffered-logger/pull/10.

It attempts to solve the concurrency issue by cloning the hash before attempting to `sweep`.

