### PR TITLE
Fix thread safety issues with buffer hash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ script: bundle exec rake test
 rvm:
   - 2.1.0
   - 2.0.0
-  - 1.9.3
-  - jruby-19mode
 env:
   - "AS_VERSION=3.2.16"
   - "AS_VERSION=4.0.2"

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,13 @@ require "rake/testtask"
 
 Rake::TestTask.new do |task|
   task.libs << "test"
+  task.test_files = Dir["test/**/*_test.rb"] - Dir["test/**/*_slow_test.rb"]
+  task.verbose = true
+end
+
+Rake::TestTask.new do |task|
+  task.name = :slow_test
+  task.libs << "test"
   task.test_files = Dir["test/**/*_test.rb"]
   task.verbose = true
 end

--- a/buffered-logger.gemspec
+++ b/buffered-logger.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.files       = Dir["lib/**/*"]
   gem.test_files  = Dir["test/**/*_test.rb"]
 
-  gem.required_ruby_version = ">= 1.9.2"
+  gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_development_dependency "mocha", "~> 0.13.3"
   gem.add_development_dependency "rake", "~> 10.0.4"

--- a/lib/buffered_logger.rb
+++ b/lib/buffered_logger.rb
@@ -40,20 +40,6 @@ class BufferedLogger < ::Logger
     @logdev.started?
   end
 
-  def sweep
-    warn "[DEPRECATION] `sweep` is deprecated.  It is no longer necessary."
-  end
-
-  def sweep_frequency=(freq)
-    warn "[DEPRECATION] `sweep_frequency=` is deprecated.  It is no longer necessary."
-    @sweep_frequency = freq
-  end
-
-  def sweep_frequency
-    warn "[DEPRECATION] `sweep_frequency` is deprecated.  It is no longer necessary."
-    @sweep_frequency || 0.02
-  end
-
   def current_log
     @logdev.current_log
   end

--- a/lib/buffered_logger.rb
+++ b/lib/buffered_logger.rb
@@ -46,10 +46,12 @@ class BufferedLogger < ::Logger
 
   def sweep_frequency=(freq)
     warn "[DEPRECATION] `sweep_frequency=` is deprecated.  It is no longer necessary."
+    @sweep_frequency = freq
   end
 
   def sweep_frequency
     warn "[DEPRECATION] `sweep_frequency` is deprecated.  It is no longer necessary."
+    @sweep_frequency || 0.02
   end
 
   def current_log

--- a/lib/buffered_logger.rb
+++ b/lib/buffered_logger.rb
@@ -6,8 +6,6 @@ class BufferedLogger < ::Logger
   require "buffered_logger/middleware"
   require "buffered_logger/version"
 
-  attr_accessor :sweep_frequency
-
   def initialize(*)
     super
     @logdev = LogDeviceProxy.new(@logdev)

--- a/lib/buffered_logger.rb
+++ b/lib/buffered_logger.rb
@@ -11,13 +11,11 @@ class BufferedLogger < ::Logger
   def initialize(*)
     super
     @logdev = LogDeviceProxy.new(@logdev)
-    self.sweep_frequency = 0.02
   end
 
   def end
     raise NotStartedError, "not started" unless started?
     @logdev.end
-    sweep if rand <= sweep_frequency
     nil
   end
 
@@ -45,7 +43,15 @@ class BufferedLogger < ::Logger
   end
 
   def sweep
-    @logdev.sweep
+    warn "[DEPRECATION] `sweep` is deprecated.  It is no longer necessary."
+  end
+
+  def sweep_frequency=(freq)
+    warn "[DEPRECATION] `sweep_frequency=` is deprecated.  It is no longer necessary."
+  end
+
+  def sweep_frequency
+    warn "[DEPRECATION] `sweep_frequency` is deprecated.  It is no longer necessary."
   end
 
   def current_log

--- a/lib/buffered_logger/log_device_proxy.rb
+++ b/lib/buffered_logger/log_device_proxy.rb
@@ -24,7 +24,7 @@ class BufferedLogger
     end
 
     def start
-      Thread.current.thread_variable_set(THREAD_LOCAL_VAR_NAME,StringIO.new)
+      self.string_io = StringIO.new
     end
 
     def started?
@@ -45,11 +45,23 @@ class BufferedLogger
 
     private
     def string_io
-      Thread.current.thread_variable_get(THREAD_LOCAL_VAR_NAME)
+      if Thread.current.respond_to?(:thread_variable_get)
+        Thread.current.thread_variable_get(THREAD_LOCAL_VAR_NAME)
+      else
+        Thread.current[THREAD_LOCAL_VAR_NAME]
+      end
+    end
+
+    def string_io=(s_io)
+      if Thread.current.respond_to?(:thread_variable_set)
+        Thread.current.thread_variable_set(THREAD_LOCAL_VAR_NAME,s_io)
+      else
+        Thread.current[THREAD_LOCAL_VAR_NAME] = s_io
+      end
     end
 
     def destroy_thread_local
-      Thread.current.thread_variable_set(THREAD_LOCAL_VAR_NAME,nil)
+      self.string_io = nil
     end
   end
 end

--- a/lib/buffered_logger/log_device_proxy.rb
+++ b/lib/buffered_logger/log_device_proxy.rb
@@ -45,19 +45,11 @@ class BufferedLogger
 
     private
     def string_io
-      if Thread.current.respond_to?(:thread_variable_get)
-        Thread.current.thread_variable_get(THREAD_LOCAL_VAR_NAME)
-      else
-        Thread.current[THREAD_LOCAL_VAR_NAME]
-      end
+      Thread.current.thread_variable_get(THREAD_LOCAL_VAR_NAME)
     end
 
-    def string_io=(s_io)
-      if Thread.current.respond_to?(:thread_variable_set)
-        Thread.current.thread_variable_set(THREAD_LOCAL_VAR_NAME,s_io)
-      else
-        Thread.current[THREAD_LOCAL_VAR_NAME] = s_io
-      end
+    def string_io=(string_io)
+      Thread.current.thread_variable_set(THREAD_LOCAL_VAR_NAME,string_io)
     end
 
     def destroy_thread_local

--- a/lib/buffered_logger/version.rb
+++ b/lib/buffered_logger/version.rb
@@ -1,5 +1,5 @@
 require "logger"
 
 class BufferedLogger < Logger
-  VERSION = "1.2.2"
+  VERSION = "2.0.0"
 end

--- a/test/buffered_logger/log_device_proxy_slow_test.rb
+++ b/test/buffered_logger/log_device_proxy_slow_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+describe "BufferedLogger::LogDeviceProxy slow tests" do
+  before do
+    @logdev = mock()
+    @proxy = BufferedLogger::LogDeviceProxy.new(@logdev)
+  end
+
+  describe "flush" do
+    it "should handle multiple thread simutaneously calling it" do
+      @logdev.stubs(:write)
+
+      8.times do |iteration|
+        threads = []
+        8.times do
+          threads << Thread.new do
+            (iteration * 10_000).times do
+              @proxy.start
+              @proxy.flush
+              @proxy.end
+            end
+          end
+        end
+        threads.each { |thr| thr.join }
+      end
+    end
+  end
+end

--- a/test/buffered_logger/log_device_proxy_test.rb
+++ b/test/buffered_logger/log_device_proxy_test.rb
@@ -59,33 +59,6 @@ describe BufferedLogger::LogDeviceProxy do
     assert_equal "12", @proxy.current_log
   end
 
-  describe "sweep" do
-    it "should check if the thread is alive" do
-      thread = mock()
-      thread.expects(:alive?).returns(true)
-      Thread.stubs(:current).returns(thread)
-
-      @proxy.start
-      @proxy.sweep
-    end
-
-    it "should remove dead threads or fibers" do
-      thread = mock()
-      thread.stubs(:alive?).returns(true)
-      Thread.stubs(:current).returns(thread)
-
-      @proxy.start
-      @proxy.sweep
-      assert @proxy.started?, "Proxy is not started"
-
-      thread.stubs(:alive?).returns(false)
-
-      @proxy.start
-      @proxy.sweep
-      assert !@proxy.started?, "Proxy is started"
-    end
-  end
-
   describe "flush" do
     it "should handle multiple thread simutaneously calling it" do
       @logdev.stubs(:write)

--- a/test/buffered_logger/log_device_proxy_test.rb
+++ b/test/buffered_logger/log_device_proxy_test.rb
@@ -58,24 +58,4 @@ describe BufferedLogger::LogDeviceProxy do
     @proxy.write("2")
     assert_equal "12", @proxy.current_log
   end
-
-  describe "flush" do
-    it "should handle multiple thread simutaneously calling it" do
-      @logdev.stubs(:write)
-
-      8.times do |iteration|
-        threads = []
-        8.times do
-          threads << Thread.new do
-            (iteration * 10_000).times do
-              @proxy.start
-              @proxy.flush
-              @proxy.end
-            end
-          end
-        end
-        threads.each { |thr| thr.join }
-      end
-    end
-  end
 end

--- a/test/buffered_logger/log_device_proxy_test.rb
+++ b/test/buffered_logger/log_device_proxy_test.rb
@@ -85,4 +85,24 @@ describe BufferedLogger::LogDeviceProxy do
       assert !@proxy.started?, "Proxy is started"
     end
   end
+
+  describe "flush" do
+    it "should handle multiple thread simutaneously calling it" do
+      @logdev.stubs(:write)
+
+      8.times do |iteration|
+        threads = []
+        8.times do
+          threads << Thread.new do
+            (iteration * 10_000).times do
+              @proxy.start
+              @proxy.flush
+              @proxy.end
+            end
+          end
+        end
+        threads.each { |thr| thr.join }
+      end
+    end
+  end
 end

--- a/test/buffered_logger_slow_test.rb
+++ b/test/buffered_logger_slow_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+describe "BufferedLogger slow tests" do
+  before do
+    @buffer = StringIO.new
+    @logger = BufferedLogger.new(@buffer)
+  end
+
+  it "should handle multiple thread simutaneously calling start with a block" do
+    16.times do
+      threads = []
+      8.times do
+        threads << Thread.new do
+          32768.times do
+            @logger.start {}
+          end
+        end
+      end
+      threads.each { |thr| thr.join }
+      sleep(0.01 * rand)
+    end
+  end
+end

--- a/test/buffered_logger_test.rb
+++ b/test/buffered_logger_test.rb
@@ -26,4 +26,19 @@ describe BufferedLogger do
       assert_equal "foo\n", @buffer.string
     end
   end
+
+  it "should handle multiple thread simutaneously calling start with a block" do
+    16.times do
+      threads = []
+      8.times do
+        threads << Thread.new do
+          32768.times do
+            @logger.start {}
+          end
+        end
+      end
+      threads.each { |thr| thr.join }
+      sleep(0.01 * rand)
+    end
+  end
 end

--- a/test/buffered_logger_test.rb
+++ b/test/buffered_logger_test.rb
@@ -26,19 +26,4 @@ describe BufferedLogger do
       assert_equal "foo\n", @buffer.string
     end
   end
-
-  it "should handle multiple thread simutaneously calling start with a block" do
-    16.times do
-      threads = []
-      8.times do
-        threads << Thread.new do
-          32768.times do
-            @logger.start {}
-          end
-        end
-      end
-      threads.each { |thr| thr.join }
-      sleep(0.01 * rand)
-    end
-  end
 end


### PR DESCRIPTION
**TLDR** Rewrote LogDeviceProxy to use thread local variables and hopefully make the gem truly thread safe.

Fixes #12 

Added two slow tests that through brute force can create the following exceptions with the old implementation of a buffer hash. 

```
BufferedLogger::LogDeviceProxy::flush#test_0001_should handle multiple thread simutaneously calling it:
NoMethodError: undefined method `string' for nil:NilClass
    /Users/james/Code/buffered-logger/lib/buffered_logger/log_device_proxy.rb:19:in `flush'
    /Users/james/Code/buffered-logger/test/buffered_logger/log_device_proxy_test.rb:99:in `block (7 levels) in <top (required)>'
    /Users/james/Code/buffered-logger/test/buffered_logger/log_device_proxy_test.rb:97:in `times'
    /Users/james/Code/buffered-logger/test/buffered_logger/log_device_proxy_test.rb:97:in `block (6 levels) in <top (required)>'
```

```
BufferedLogger#test_0003_should handle multiple thread simutaneously calling start with a block:
BufferedLogger::AlreadyStartedError: already started
    /Users/james/Code/buffered-logger/lib/buffered_logger.rb:29:in `start'
    test/buffered_logger_test.rb:36:in `block (6 levels) in <main>'
    test/buffered_logger_test.rb:35:in `times'
    test/buffered_logger_test.rb:35:in `block (5 levels) in <main>'
```

```
BufferedLogger#test_0003_should handle multiple thread simutaneously calling start with a block:
BufferedLogger::NotStartedError: not started
    /Users/james/Code/buffered-logger/lib/buffered_logger.rb:18:in `end'
    /Users/james/Code/buffered-logger/lib/buffered_logger.rb:36:in `start'
    test/buffered_logger_test.rb:36:in `block (6 levels) in <main>'
    test/buffered_logger_test.rb:35:in `times'
    test/buffered_logger_test.rb:35:in `block (5 levels) in <main>'
```

```
BufferedLogger#test_0003_should handle multiple thread simutaneously calling start with a block:
NoMethodError: undefined method `string' for nil:NilClass
    /Users/james/Code/buffered-logger/lib/buffered_logger/log_device_proxy.rb:15:in `end'
    /Users/james/Code/buffered-logger/lib/buffered_logger.rb:19:in `end'
    /Users/james/Code/buffered-logger/lib/buffered_logger.rb:36:in `start'
    test/buffered_logger_test.rb:36:in `block (6 levels) in <main>'
    test/buffered_logger_test.rb:35:in `times'
    test/buffered_logger_test.rb:35:in `block (5 levels) in <main>'
```

Or sometimes would seg fault MRI :worried: 

```
/Users/james/Code/buffered-logger/lib/buffered_logger/log_device_proxy.rb:15: [BUG] Segmentation fault at 0x007f8f44100000
ruby 2.1.7p400 (2015-08-18 revision 51632) [x86_64-darwin14.0]

-- Crash Report log information --------------------------------------------
   See Crash Report log file under the one of following:
     * ~/Library/Logs/CrashReporter
     * /Library/Logs/CrashReporter
     * ~/Library/Logs/DiagnosticReports
     * /Library/Logs/DiagnosticReports
   for more details.

-- Control frame information -----------------------------------------------
c:0008 p:---- s:0025 e:000024 CFUNC  :delete
c:0007 p:0015 s:0021 e:000019 METHOD /Users/james/Code/buffered-logger/lib/buffered_logger/log_device_proxy.rb:15
c:0006 p:0029 s:0017 e:000016 METHOD /Users/james/Code/buffered-logger/lib/buffered_logger.rb:19
c:0005 p:0048 s:0014 e:000012 METHOD /Users/james/Code/buffered-logger/lib/buffered_logger.rb:36
c:0004 p:0009 s:0009 E:001e68 BLOCK  test/buffered_logger_test.rb:36 [FINISH]
c:0003 p:---- s:0007 e:000006 CFUNC  :times
c:0002 p:0010 s:0004 E:002128 BLOCK  test/buffered_logger_test.rb:35 [FINISH]
c:0001 p:---- s:0002 e:000001 TOP    [FINISH]

test/buffered_logger_test.rb:35:in `block (5 levels) in <main>'
test/buffered_logger_test.rb:35:in `times'
```

All the exceptions related to simultaneously accessing the @buffers hash in LogDeviceProxy. I didn't see a reason why we couldn't move the current StringIO to a thread local variable so I re-implemented it using thread local. Otherwise we'd need a mutex around access of the @buffers hash or more of the dup the hash dance we were doing before.

Bumped the version number along with these changes and also deprecated the sweep functionality since it was no longer needed with the new implementation.
